### PR TITLE
feat: Green light on open door

### DIFF
--- a/Core/Inc/wiegand.h
+++ b/Core/Inc/wiegand.h
@@ -14,6 +14,9 @@
 #define WIEGAND_BUZZER_PORT OUT0_GPIO_Port
 #define WIEGAND_BUZZER_PIN OUT0_Pin
 
+#define WIEGAND_STATUS_PORT OUT1_GPIO_Port
+#define WIEGAND_STATUS_PIN OUT1_Pin
+
 #define WIEGAND_ENABLED 
 
 void canpybara_wiegand_reset(void);

--- a/Core/Src/wiegand.c
+++ b/Core/Src/wiegand.c
@@ -189,18 +189,23 @@ static uint32_t canpybara_wiegand_strip_parity_bits(uint32_t input)
 
 void canpybara_wiegand_zone_response(uint8_t response)
 {
-	if(response == 0)
-	{
-		LOG("Opening");
-		HAL_GPIO_WritePin(WIEGAND_RELAY_PORT, WIEGAND_RELAY_PIN, GPIO_PIN_SET);
-	}
-	else
-	{
-		LOG("Reject");
-		HAL_GPIO_WritePin(WIEGAND_BUZZER_PORT, WIEGAND_BUZZER_PIN, GPIO_PIN_SET);
-	}
+    if(response == 0)
+    {
+        LOG("Opening");
+        HAL_GPIO_WritePin(WIEGAND_RELAY_PORT, WIEGAND_RELAY_PIN, GPIO_PIN_SET);
+        HAL_GPIO_WritePin(WIEGAND_STATUS_PORT, WIEGAND_STATUS_PIN, GPIO_PIN_SET);
+        HAL_GPIO_WritePin(WIEGAND_BUZZER_PORT, WIEGAND_BUZZER_PIN, GPIO_PIN_RESET);
+    }
+    else
+    {
+        LOG("Reject");
+        HAL_GPIO_WritePin(WIEGAND_RELAY_PORT, WIEGAND_RELAY_PIN, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(WIEGAND_STATUS_PORT, WIEGAND_STATUS_PIN, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(WIEGAND_BUZZER_PORT, WIEGAND_BUZZER_PIN, GPIO_PIN_SET);
+    }
 
-	HAL_TIM_Base_Start_IT(&htim3);
+    __HAL_TIM_SET_COUNTER(&htim3, 0);
+    HAL_TIM_Base_Start_IT(&htim3);
 }
 
 void canpybara_wiegand_zone_timeout(void)
@@ -209,6 +214,7 @@ void canpybara_wiegand_zone_timeout(void)
 
     HAL_TIM_Base_Stop_IT(&htim3);
 
-	HAL_GPIO_WritePin(WIEGAND_RELAY_PORT, WIEGAND_RELAY_PIN, GPIO_PIN_RESET);
-	HAL_GPIO_WritePin(WIEGAND_BUZZER_PORT, WIEGAND_BUZZER_PIN, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(WIEGAND_RELAY_PORT, WIEGAND_RELAY_PIN, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(WIEGAND_STATUS_PORT, WIEGAND_STATUS_PIN, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(WIEGAND_BUZZER_PORT, WIEGAND_BUZZER_PIN, GPIO_PIN_RESET);
 }


### PR DESCRIPTION
Added output for green status light when card is accepted and door is unlocked. Also fixed error when timer is not reset when another read occurs before timer stops.