### PR TITLE
fix: Remove canbus spam

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Move artifacts
       run: mkdir artifacts && cp build/canpybara.bin build/canpybara.hex build/canpybara.elf artifacts/
     - name: Upload artifacts
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4
       with:
         name: binaries
         path: artifacts

--- a/Core/Src/stm32f1xx_it.c
+++ b/Core/Src/stm32f1xx_it.c
@@ -392,7 +392,11 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
   // Periodic CAN reports
   if(htim == &htim1)
   {
+    #ifdef WIEGAND_ENABLED
+    #warning Wiegand enabled: GPIO periodic report will be disabled
+    #else
     canpybara_gpio_report();
+    #endif
   }
   
   // Debounce filter


### PR DESCRIPTION
Canpybaras are spaming about GPIO input, which is unused on wiegand mode. GPIO reports are now disabled when wiegand is enabled.