### PR TITLE
fix: First open/error timeout firing immediately.

### DIFF
--- a/Core/Src/wiegand.c
+++ b/Core/Src/wiegand.c
@@ -205,6 +205,7 @@ void canpybara_wiegand_zone_response(uint8_t response)
     }
 
     __HAL_TIM_SET_COUNTER(&htim3, 0);
+    __HAL_TIM_CLEAR_FLAG(&htim3, TIM_FLAG_UPDATE);
     HAL_TIM_Base_Start_IT(&htim3);
 }
 


### PR DESCRIPTION
First timeout for opening door or indicating error was firing immediately due to interrupt flag being set after the boot. This also improves stability of quick subsequent reads, as the interrupt flag is now cleared before enabling the interrupt.